### PR TITLE
removed secret_name

### DIFF
--- a/siteshield/siteshield.py
+++ b/siteshield/siteshield.py
@@ -16,7 +16,6 @@ debug = str(os.getenv("DEBUG")) == "True"
 secret_arn = os.getenv("SECRET_ARN")
 bucket_name = os.getenv("BUCKET")
 force_cache = str(os.getenv("FORCE_CACHE")) == "True"
-secret_name = secret_arn.split(":")[-1]
 
 def handler(event, context):
   if debug: logger.info("siteshield.py : Handler : start with debugging")
@@ -33,7 +32,7 @@ def handler(event, context):
       contents = s3_get()
     else :
       try:
-        get_secret_value_response = boto3.client("secretsmanager").get_secret_value(SecretId=secret_name)
+        get_secret_value_response = boto3.client("secretsmanager").get_secret_value(SecretId=secret_arn)
         get_secret_json = json.loads(get_secret_value_response["SecretString"])
         client_secret = get_secret_json["client_secret"]
         host = get_secret_json["host"]


### PR DESCRIPTION
When a secret in AWS is created, a unique string is added to the end of the ARN to ensure the ARN is unique. 

arn:aws:secretsmanager:<Region>:<AccountId>:secret:SecretName-6RandomCharacters

When the script attempts to derive the secret_name from the secret_arn variable, the value of secret_name is set to SecretName-6RandomCharacters. This value is then being passed get_secret_value() which fails to find the resource "SecretName-6RandomCharacters" as the actual name on the AWS secret is "SecretName".

get_secret_value() accepts the secret ARN as a value to fetch the contents of the AWS secret, eliminating the need to painfully formulate the bucket_name from the ARN altogether.